### PR TITLE
Add web API for ESP32 LED control and update documentation

### DIFF
--- a/.idx/dev.nix
+++ b/.idx/dev.nix
@@ -1,0 +1,55 @@
+# To learn more about how to use Nix to configure your environment
+# see: https://firebase.google.com/docs/studio/customize-workspace
+{ pkgs, ... }: {
+  # Which nixpkgs channel to use.
+  channel = "stable-24.05"; # or "unstable"
+
+  # Use https://search.nixos.org/packages to find packages
+  packages = [
+    # pkgs.go
+    # pkgs.python311
+    # pkgs.python311Packages.pip
+    # pkgs.nodejs_20
+    # pkgs.nodePackages.nodemon
+  ];
+
+  # Sets environment variables in the workspace
+  env = {};
+  idx = {
+    # Search for the extensions you want on https://open-vsx.org/ and use "publisher.id"
+    extensions = [
+      # "vscodevim.vim"
+    ];
+
+    # Enable previews
+    previews = {
+      enable = true;
+      previews = {
+        # web = {
+        #   # Example: run "npm run dev" with PORT set to IDX's defined port for previews,
+        #   # and show it in IDX's web preview panel
+        #   command = ["npm" "run" "dev"];
+        #   manager = "web";
+        #   env = {
+        #     # Environment variables to set for your server
+        #     PORT = "$PORT";
+        #   };
+        # };
+      };
+    };
+
+    # Workspace lifecycle hooks
+    workspace = {
+      # Runs when a workspace is first created
+      onCreate = {
+        # Example: install JS dependencies from NPM
+        # npm-install = "npm install";
+      };
+      # Runs when the workspace is (re)started
+      onStart = {
+        # Example: start a background task to watch and re-build backend code
+        # watch-backend = "npm run watch-backend";
+      };
+    };
+  };
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,4 @@
+{
+    "IDX.aI.enableInlineCompletion": true,
+    "IDX.aI.enableCodebaseIndexing": true
+}

--- a/README.md
+++ b/README.md
@@ -25,3 +25,35 @@ This is a PlatformIO project. You will need to have PlatformIO Core installed to
 - Framework: Arduino
 
 Refer to the `platformio.ini` file for detailed configuration.
+
+## Ubuntu Setup for Serial Port Access
+
+On Ubuntu, you might encounter permissions errors when trying to upload code to the ESP32 board, as the default user often doesn't have access to serial ports like `/dev/ttyUSB0`. Follow these steps to resolve this:
+
+1.  **Download the udev rules file:**
+    ```bash
+    sudo curl -L https://raw.githubusercontent.com/platformio/platformio-core/develop/platformio/assets/system/99-platformio-udev.rules -o /etc/udev/rules.d/99-platformio-udev.rules
+    ```
+    This downloads the necessary udev rules that allow access to USB devices used by PlatformIO. You will be prompted for your password.
+
+2.  **Reload udev rules:**
+    ```bash
+    sudo udevadm control --reload-rules
+    ```
+    This command tells the udev system to load the new rules you just added.
+
+3.  **Trigger udev:**
+    ```bash
+    sudo udevadm trigger
+    ```
+    This command reapplies the udev rules to the currently connected devices.
+
+4.  **Add your user to the `dialout` group:**
+    ```bash
+    sudo usermod -a -G dialout $USER
+    ```
+    Grant your user permissions to access serial ports by adding them to the `dialout` group.
+
+5.  **Log out and Log In:** For the group membership change to take effect, you must log out of your Ubuntu session and log back in (or restart your computer).
+
+After following these steps, you should have the necessary permissions to upload code to your ESP32 board without encountering the "Could not open /dev/ttyUSB0" error.

--- a/data/index.html
+++ b/data/index.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>ESP32 Status</title>
+    <style>
+        body {
+            font-family: Arial, sans-serif;
+            text-align: center;
+            margin-top: 50px;
+        }
+        h1 {
+            color: #333;
+        }
+        .status {
+            margin-top: 20px;
+            font-size: 1.2em;
+        }
+    </style>
+</head>
+<body>
+    <h1>ESP32 Device Status</h1>
+    <div class="status">
+        <p>Device is connected.</p>
+        <p>Blinking program is running.</p>
+    </div>
+</body>
+</html>

--- a/laptop_index.html
+++ b/laptop_index.html
@@ -1,0 +1,64 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>ESP32 Control</title>
+    <style>
+        body {
+            font-family: Arial, sans-serif;
+            text-align: center;
+            margin-top: 50px;
+        }
+        h1 {
+            color: #333;
+        }
+        #status {
+            margin-top: 20px;
+            font-size: 1.2em;
+        }
+        button {
+            padding: 10px 20px;
+            font-size: 1em;
+            cursor: pointer;
+        }
+    </style>
+</head>
+<body>
+    <h1>ESP32 LED Control</h1>
+    <div id="status">
+        <p>Connecting to ESP32...</p>
+    </div>
+    <button onclick="toggleLED()">Toggle LED</button>
+
+    <script>
+        // IMPORTANT: Replace with the actual IP address of your ESP32
+        const esp32Ip = 'YOUR_ESP32_IP_ADDRESS'; 
+
+        async function toggleLED() {
+            try {
+                const response = await fetch(`http://${esp32Ip}/led/toggle`);
+                const data = await response.text();
+                document.getElementById('status').innerText = data;
+            } catch (error) {
+                console.error('Error toggling LED:', error);
+                document.getElementById('status').innerText = 'Error connecting to ESP32.';
+            }
+        }
+
+        // Optional: Function to get initial LED state when the page loads
+        async function getLEDState() {
+             try {
+                const response = await fetch(`http://${esp32Ip}/led/state`);
+                const data = await response.text();
+                document.getElementById('status').innerText = `LED is initially ${data}`; // Display initial state
+            } catch (error) {
+                console.error('Error getting LED state:', error);
+                document.getElementById('status').innerText = 'Could not get initial LED state.';
+            }
+        }
+
+        // Call getLEDState when the page loads (optional)
+        // window.onload = getLEDState;
+
+    </script>
+</body>
+</html>

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,18 +1,81 @@
 #include <Arduino.h>
+#include <WiFi.h>
+#include <ESPAsyncWebServer.h>
+#include <LittleFS.h>
 
-// put function declarations here:
-int myFunction(int, int);
+// Define the LED pin (replace with your actual LED pin)
+const int ledPin = 2; // Commonly the built-in LED on ESP32 boards
+
+// Replace with your network credentials
+const char* ssid = "prab_jiofiber"; // Your local Wi-Fi SSID
+const char* password = "cherryrocks"; // Your local Wi-Fi password
+
+AsyncWebServer server(80);
+
+// Variable to keep track of the LED state
+bool ledState = false; // Start with LED off
 
 void setup() {
-  // put your setup code here, to run once:
-  int result = myFunction(2, 3);
+  Serial.begin(115200);
+  delay(1000);
+
+  pinMode(ledPin, OUTPUT);
+  digitalWrite(ledPin, !ledState); // Set initial LED state
+
+  // Initialize LittleFS
+  if (!LittleFS.begin(true)) {
+    Serial.println("An Error has occurred while mounting LittleFS");
+    return;
+  }
+  Serial.println("LittleFS initialized.");
+
+  // Connect to Wi-Fi network
+  Serial.print("Connecting to WiFi...");
+  WiFi.begin(ssid, password);
+
+  while (WiFi.status() != WL_CONNECTED) {
+    delay(1000);
+    Serial.print(".");
+  }
+
+  Serial.println("
+Connected to WiFi!");
+  Serial.print("IP address: ");
+  Serial.println(WiFi.localIP());
+
+  // Serve index.html from LittleFS (optional, could be served from laptop too)
+  server.on("/", HTTP_GET, [](AsyncWebServerRequest *request){
+    request->send(LittleFS, "/index.html", "text/html");
+  });
+
+  // API endpoint to toggle LED state
+  server.on("/led/toggle", HTTP_GET, [](AsyncWebServerRequest *request){
+    ledState = !ledState; // Toggle the state
+    digitalWrite(ledPin, !ledState); // Update the LED
+    request->send(200, "text/plain", ledState ? "LED is now ON" : "LED is now OFF");
+  });
+
+  // API endpoint to get LED state (optional)
+  server.on("/led/state", HTTP_GET, [](AsyncWebServerRequest *request){
+    request->send(200, "text/plain", ledState ? "ON" : "OFF");
+  });
+
+
+  // Handle not found
+  server.onNotFound([](AsyncWebServerRequest *request){
+    request->send(404, "text/plain", "Not found");
+  });
+
+  // Start server
+  server.begin();
+  Serial.println("HTTP server started");
 }
 
 void loop() {
-  // put your main code here, to run repeatedly:
-}
-
-// put function definitions here:
-int myFunction(int x, int y) {
-  return x + y;
+  // Keep the LED blinking logic for now, but it will be overridden by API calls
+  // You might remove this blinking logic if you only want API control.
+  digitalWrite(ledPin, HIGH); // Turn the LED on (HIGH is usually off for built-in LED)
+  delay(500);
+  digitalWrite(ledPin, LOW);  // Turn the LED off
+  delay(500);
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -38,8 +38,7 @@ void setup() {
     Serial.print(".");
   }
 
-  Serial.println("
-Connected to WiFi!");
+  Serial.println("\nConnected to WiFi!");
   Serial.print("IP address: ");
   Serial.println(WiFi.localIP());
 


### PR DESCRIPTION
Introduce a web API feature to control an LED on the ESP32, including endpoints for toggling the LED state and retrieving its status. Update the README to include setup instructions for Ubuntu users regarding serial port access. Fix a newline issue in the configuration file.